### PR TITLE
Improved performance of sprite rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ BuiltXnbs/
 # JUSTIN 3/14/21 - this is removing legitimate music files
 # *.ogg
 
+# Rider IDE files
+.idea/
+
 # Created by https://www.gitignore.io/api/visualstudio
 # Edit at https://www.gitignore.io/?templates=visualstudio
 

--- a/Glade2d/Game.cs
+++ b/Glade2d/Game.cs
@@ -1,4 +1,6 @@
-﻿using Glade2d.Graphics;
+﻿using System;
+using System.Diagnostics;
+using Glade2d.Graphics;
 using Glade2d.Screens;
 using Glade2d.Services;
 using Meadow.Foundation.Graphics;
@@ -8,6 +10,8 @@ namespace Glade2d
 {
     public class Game
     {
+        private readonly Stopwatch _stopwatch = new Stopwatch();
+        
         /// <summary>
         /// The engine operating mode, this can currently only be set
         /// during Initialize
@@ -69,8 +73,15 @@ namespace Glade2d
         /// </summary>
         public void Tick()
         {
+            _stopwatch.Restart();
             Update();
+            var updateTime = _stopwatch.ElapsedMilliseconds;
             Draw();
+            _stopwatch.Stop();
+            var totalTime = _stopwatch.ElapsedMilliseconds;
+            var drawTime = totalTime - updateTime;
+            
+            Console.WriteLine($"Update: {updateTime}ms, Draw: {drawTime}ms");
         }
 
         /// <summary>
@@ -90,19 +101,35 @@ namespace Glade2d
         /// </summary>
         public void Draw()
         {
+            var accessTime = TimeSpan.Zero;
+            var drawTime = TimeSpan.Zero;
+            var startTime = _stopwatch.Elapsed;
             Renderer.Reset();
+            var resetTime = _stopwatch.Elapsed;
             var screen = GameService.Instance.CurrentScreen;
             if (screen != null)
             {
                 // TODO: this is a hack, figure out how to protect list
                 // while also making it available to the renderer
                 var sprites = screen.AccessSpritesForRenderingOnly();
+                accessTime = _stopwatch.Elapsed;
                 for (var i = 0; i < sprites.Count; i++)
                 {
                     Renderer.DrawSprite(sprites[i]);
                 }
+
+                drawTime = _stopwatch.Elapsed;
             }
+            
             Renderer.RenderToDisplay();
+            var totalTime = _stopwatch.Elapsed;
+            
+            Console.WriteLine($"Draw timings: " +
+                              $"Reset: {(resetTime - startTime).TotalMilliseconds}ms " +
+                              $"Access: {(accessTime - resetTime).TotalMilliseconds}ms " +
+                              $"Draw: {(drawTime - accessTime).TotalMilliseconds}ms " +
+                              $"Render: {(totalTime - drawTime).TotalMilliseconds}ms ");
+            
         }
     }
 }

--- a/Glade2d/Game.cs
+++ b/Glade2d/Game.cs
@@ -112,6 +112,7 @@ namespace Glade2d
                 // TODO: this is a hack, figure out how to protect list
                 // while also making it available to the renderer
                 var sprites = screen.AccessSpritesForRenderingOnly();
+                Console.WriteLine($"Sprite count: {sprites.Count}");
                 accessTime = _stopwatch.Elapsed;
                 for (var i = 0; i < sprites.Count; i++)
                 {

--- a/Glade2d/Graphics/Renderer.cs
+++ b/Glade2d/Graphics/Renderer.cs
@@ -12,6 +12,8 @@ namespace Glade2d.Graphics
 {
     public class Renderer : MicroGraphics
     {
+        private int _width, _height;
+        
         readonly Dictionary<string, IPixelBuffer> textures = new Dictionary<string, IPixelBuffer>();
         public Color BackgroundColor { get; set; } = Color.Black;
         public Color TransparentColor { get; set; } = Color.Magenta;
@@ -50,6 +52,8 @@ namespace Glade2d.Graphics
         public void Reset()
         {
             pixelBuffer.Fill(BackgroundColor);
+            _width = Width;
+            _height = Height;
         }
 
         /// <summary>
@@ -69,25 +73,35 @@ namespace Glade2d.Graphics
             var transparentByte2 = (byte)(TransparentColor.Color16bppRgb565 & 0x00FF);
 
             var imgBuffer = textures[frame.TextureName];
-            for (var x = frame.X; x < frame.X + frame.Width; x++)
+
+            var imgBufferWidth = imgBuffer.Width;
+            var pixelBufferWidth = pixelBuffer.Width;
+            var frameHeight = frame.Height;
+            var frameWidth = frame.Width;
+            var frameX = frame.X;
+            var frameY = frame.Y;
+            var innerPixelBuffer = pixelBuffer.Buffer;
+            var innerImgBuffer = imgBuffer.Buffer;
+            
+            for (var x = frameX; x < frameX + frameWidth; x++)
             {
-                for (var y = frame.Y; y < frame.Y + frame.Height; y++)
+                for (var y = frameY; y < frameY + frameHeight; y++)
                 {
-                    var tX = originX + x - frame.X;
-                    var tY = originY + y - frame.Y;
+                    var tX = originX + x - frameX;
+                    var tY = originY + y - frameY;
 
                     // only draw if not transparent and within buffer
-                    if (tX >= 0 && tY >= 0 && tX < Width && tY < Height)
+                    if (tX >= 0 && tY >= 0 && tX < _width && tY < _height)
                     {
                         // temp assume rgb565
-                        var frameIndex = (y * imgBuffer.Width + x) * sizeof(ushort);
-                        var colorByte1 = imgBuffer.Buffer[frameIndex];
-                        var colorByte2 = imgBuffer.Buffer[frameIndex + 1];
+                        var frameIndex = (y * imgBufferWidth + x) * sizeof(ushort);
+                        var colorByte1 = innerImgBuffer[frameIndex];
+                        var colorByte2 = innerImgBuffer[frameIndex + 1];
                         if (colorByte1 != transparentByte1 || colorByte2 != transparentByte2)
                         {
-                            var bufferIndex = (tY * pixelBuffer.Width + tX) * sizeof(ushort);
-                            pixelBuffer.Buffer[bufferIndex] = colorByte1;
-                            pixelBuffer.Buffer[bufferIndex + 1] = colorByte2;
+                            var bufferIndex = (tY * pixelBufferWidth + tX) * sizeof(ushort);
+                            innerPixelBuffer[bufferIndex] = colorByte1;
+                            innerPixelBuffer[bufferIndex + 1] = colorByte2;
                         }
                     }
                 }

--- a/Glade2d/Graphics/Renderer.cs
+++ b/Glade2d/Graphics/Renderer.cs
@@ -70,7 +70,6 @@ namespace Glade2d.Graphics
             {
                 for (var y = frame.Y; y < frame.Y + frame.Height; y++)
                 {
-                    // var pixel = Color.Aqua; 
                     var pixel = imgBuffer.GetPixel(x, y);
                     var tX = originX + x - frame.X;
                     var tY = originY + y - frame.Y;

--- a/Glade2d/Graphics/Renderer.cs
+++ b/Glade2d/Graphics/Renderer.cs
@@ -65,23 +65,30 @@ namespace Glade2d.Graphics
                 LoadTexture(frame.TextureName);
             }
 
+            var transparentByte1 = (byte)(TransparentColor.Color16bppRgb565 >> 8);
+            var transparentByte2 = (byte)(TransparentColor.Color16bppRgb565 & 0x00FF);
+
             var imgBuffer = textures[frame.TextureName];
             for (var x = frame.X; x < frame.X + frame.Width; x++)
             {
                 for (var y = frame.Y; y < frame.Y + frame.Height; y++)
                 {
-                    var pixel = imgBuffer.GetPixel(x, y);
                     var tX = originX + x - frame.X;
                     var tY = originY + y - frame.Y;
 
                     // only draw if not transparent and within buffer
-                    if (pixel != TransparentColor &&
-                        tX >= 0 &&
-                        tY >= 0 &&
-                        tX < Width &&
-                        tY < Height)
+                    if (tX >= 0 && tY >= 0 && tX < Width && tY < Height)
                     {
-                        DrawPixel(tX, tY, pixel);
+                        // temp assume rgb565
+                        var frameIndex = (y * imgBuffer.Width + x) * sizeof(ushort);
+                        var colorByte1 = imgBuffer.Buffer[frameIndex];
+                        var colorByte2 = imgBuffer.Buffer[frameIndex + 1];
+                        if (colorByte1 != transparentByte1 || colorByte2 != transparentByte2)
+                        {
+                            var bufferIndex = (tY * pixelBuffer.Width + tX) * sizeof(ushort);
+                            pixelBuffer.Buffer[bufferIndex] = colorByte1;
+                            pixelBuffer.Buffer[bufferIndex + 1] = colorByte2;
+                        }
                     }
                 }
             }
@@ -137,24 +144,10 @@ namespace Glade2d.Graphics
 
                 LogService.Log.Trace($"Got image at {img.BitsPerPixel} and buffer is {pixelBuffer.BitDepth}");
 
-                // if our loaded image buffer is the same color depth, we can just
-                // directly use the image's display buffer
-                // NOTE: it would be better to check actual ColorType but the image
-                // buffer doesn't have a ColorType property, only BitsPerPixel
-                if (img.BitsPerPixel == pixelBuffer.BitDepth)
-                {
-                    imgBuffer = img.DisplayBuffer;
-                }
-
-                // if our loaded image has a different color depth we do a one-time,
-                // pixel-by-pixel slow copy into a matching buffer to make future
-                // buffer blitting much faster!
-                else
-                {
-                    LogService.Log.Info($"Image {name} is wrong bit depth ({img.BitsPerPixel}bpp), matching buffer depth of {pixelBuffer.BitDepth}.");
-                    imgBuffer = GetBufferForColorMode(pixelBuffer.ColorMode, img.Width, img.Height);
-                    imgBuffer.WriteBuffer(0, 0, img.DisplayBuffer);
-                }
+                // Always make sure that the texture is formatted in the same color mode as the display
+                LogService.Log.Info($"Image {name} is wrong bit depth ({img.BitsPerPixel}bpp), matching buffer depth of {pixelBuffer.BitDepth}.");
+                imgBuffer = GetBufferForColorMode(pixelBuffer.ColorMode, img.Width, img.Height);
+                imgBuffer.WriteBuffer(0, 0, img.DisplayBuffer);
 
                 LogService.Log.Trace($"{name} loaded to buffer of type {imgBuffer.GetType()}");
                 return imgBuffer;
@@ -249,11 +242,15 @@ namespace Glade2d.Graphics
                 // destination buffer
                 for (int x = 0; x < pixelBuffer.Width; x++)
                 {
-                    var color = pixelBuffer.GetPixel(x, y);
+                    var frameIndex = (y * pixelBuffer.Width + x) * sizeof(ushort);
+                    var colorByte1 = pixelBuffer.Buffer[frameIndex];
+                    var colorByte2 = pixelBuffer.Buffer[frameIndex + 1];
                     var xScaled = x * Scale;
                     for (var i = 0; i < Scale; i++)
                     {
-                        display.DrawPixel(xScaled + i, yScaled, color);
+                        var index = (yScaled * pixelBuffer.Width + xScaled + i) * sizeof(ushort);
+                        displayBuffer[index] = colorByte1;
+                        displayBuffer[index + 1] = colorByte2;
                     }
                 }
 

--- a/Glade2d/Graphics/Renderer.cs
+++ b/Glade2d/Graphics/Renderer.cs
@@ -15,7 +15,7 @@ namespace Glade2d.Graphics
         readonly Dictionary<string, IPixelBuffer> textures = new Dictionary<string, IPixelBuffer>();
         public Color BackgroundColor { get; set; } = Color.Black;
         public Color TransparentColor { get; set; } = Color.Magenta;
-        public bool ShowPerf { get; set; } = false;
+        public bool ShowPerf { get; set; } = true;
         public int Scale { get; private set; }
         public bool UseTransparency { get; set; } = true;
         public bool RenderInSafeMode { get; set; } = false;
@@ -70,13 +70,21 @@ namespace Glade2d.Graphics
             {
                 for (var y = frame.Y; y < frame.Y + frame.Height; y++)
                 {
+                    // var pixel = Color.Aqua; 
                     var pixel = imgBuffer.GetPixel(x, y);
+                    if (pixel.R == TransparentColor.R &&
+                        pixel.G == TransparentColor.G &&
+                        pixel.B == TransparentColor.B &&
+                        pixel.A == TransparentColor.A)
+                    {
+                        continue;
+                    }
+                    
                     var tX = originX + x - frame.X;
                     var tY = originY + y - frame.Y;
 
                     // only draw if not transparent and within buffer
-                    if (!pixel.Equals(TransparentColor) &&
-                        tX >= 0 &&
+                    if (tX >= 0 &&
                         tY >= 0 &&
                         tX < Width &&
                         tY < Height)

--- a/Glade2d/Graphics/Renderer.cs
+++ b/Glade2d/Graphics/Renderer.cs
@@ -72,19 +72,12 @@ namespace Glade2d.Graphics
                 {
                     // var pixel = Color.Aqua; 
                     var pixel = imgBuffer.GetPixel(x, y);
-                    if (pixel.R == TransparentColor.R &&
-                        pixel.G == TransparentColor.G &&
-                        pixel.B == TransparentColor.B &&
-                        pixel.A == TransparentColor.A)
-                    {
-                        continue;
-                    }
-                    
                     var tX = originX + x - frame.X;
                     var tY = originY + y - frame.Y;
 
                     // only draw if not transparent and within buffer
-                    if (tX >= 0 &&
+                    if (pixel != TransparentColor &&
+                        tX >= 0 &&
                         tY >= 0 &&
                         tX < Width &&
                         tY < Height)

--- a/Samples/SampleInput/MeadowApp.cs
+++ b/Samples/SampleInput/MeadowApp.cs
@@ -60,7 +60,7 @@ namespace SampleInput
         {
             LogService.Log.Trace("Starting Glade2d...");
             glade = new Game();
-            glade.Initialize(display, 2, EngineMode.RenderOnDemand, RotationType._90Degrees);
+            glade.Initialize(display, 1, EngineMode.RenderOnDemand, RotationType._90Degrees);
             glade.Start();
         }
 

--- a/Samples/SampleProjectLab/MeadowApp.cs
+++ b/Samples/SampleProjectLab/MeadowApp.cs
@@ -21,7 +21,7 @@ namespace SampleProjectLab
         {
             LogService.Log.Trace("Initializing Glade game engine...");
             glade = new Game();
-            glade.Initialize(display, 2, EngineMode.GameLoop, RotationType._90Degrees);
+            glade.Initialize(display, 1, EngineMode.GameLoop, RotationType._90Degrees);
 
             LogService.Log.Trace("Running game...");
             glade.Start(new GladeDemoScreen());


### PR DESCRIPTION
A significant portion of rendering a sprite is tied up in color equality.  The call to `!pixel.Equals(TransparentColor)` is slow because it uses the `Equals(object)` override, which internally has to have a type check and cast of the parameter.  Switching to `!=` uses the implementation that requires no casting, and therefore is significantly faster.

Similarly, the per sprite rendering code that iterated pixel by pixel was improved, bringing the draw times for ~47 sprites down to 20ms.  This is done by making sure the only calculations that happen in the per-pixel loop are actual pixel related calculations, and removing all getters out of the loop. This presumably helps cache and provided a good performance boost.

These changes took the sample app from ~1.3fps to 5.6fps.

This PR also adds in some stdout diagnostics for render timings.

Note that this PR breaks non-100% scaled rendering, that will be addressed later.