### PR TITLE
Fixed scaled rendering for index based painting

### DIFF
--- a/Glade2d/Graphics/Renderer.cs
+++ b/Glade2d/Graphics/Renderer.cs
@@ -282,8 +282,8 @@ namespace Glade2d.Graphics
                 // drawing pixel-by-pixel!
                 for (var i = 1; i < Scale; i++)
                 {
-                    var copyFromStartIndex = yScaled * displayBufferWidth* BytesPerPixel;
-                    var copyToStartIndex = yScaled * displayBufferWidth * BytesPerPixel;
+                    var copyFromStartIndex = yScaled * displayBufferWidth * BytesPerPixel;
+                    var copyToStartIndex = (yScaled + i) * displayBufferWidth * BytesPerPixel;
                     
                     Array.Copy(displayBuffer, copyFromStartIndex, displayBuffer, copyToStartIndex, displayBytesPerRow);
                 }

--- a/Samples/SampleProjectLab/MeadowApp.cs
+++ b/Samples/SampleProjectLab/MeadowApp.cs
@@ -21,7 +21,7 @@ namespace SampleProjectLab
         {
             LogService.Log.Trace("Initializing Glade game engine...");
             glade = new Game();
-            glade.Initialize(display, 1, EngineMode.GameLoop, RotationType._90Degrees);
+            glade.Initialize(display, 2, EngineMode.GameLoop, RotationType._90Degrees);
 
             LogService.Log.Trace("Running game...");
             glade.Start(new GladeDemoScreen());


### PR DESCRIPTION
When rendering was switched to be index based (instead of `GetPixel()/SetPixel()` based), a mistake was made where the initial color bytes were written to the display buffer but the scaling/replicated bytes as written to the source/pixel buffer. This caused the display to never get the scaling bytes, and therefore the display was only scaled in one direction.

This fixes that bug and has scaled rendering working again.  Some slight refactoring, naming, and small performance improvements was done to make `ShowFastMode()` performance close to non-scaled rendering (only 10ms slower for scale of 2).