### PR TITLE
Ignore missing xml comment warnings

### DIFF
--- a/Glade2d/Glade2d.csproj
+++ b/Glade2d/Glade2d.csproj
@@ -12,6 +12,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<RootNamespace>Glade2d</RootNamespace>
 		<Description>Glade2d Microcontroller Game Engine</Description>
+		<NoWarn>1591</NoWarn>
 	</PropertyGroup>
   <ItemGroup>
     <Compile Remove="Content\**" />

--- a/Glade2d/Utility/RandomExtensions.cs
+++ b/Glade2d/Utility/RandomExtensions.cs
@@ -25,7 +25,7 @@ namespace Glade2d.Utility
         /// <param name="min">The inclusive minimum value</param>
         /// <param name="max">The exclusive maximum value</param>
         /// <returns>A random single precision number</returns>
-        public static float Between(this Random rand, float min, float max)
+        public static float Between(this Random random, float min, float max)
         {
             // early out for equal. This may not be perfectly accurate
             // but it makes no difference, all it's doing is saving
@@ -36,7 +36,7 @@ namespace Glade2d.Utility
             }
 
             var range = max - min;
-            var randInRange = (float)(rand.NextDouble() * range);
+            var randInRange = (float)(random.NextDouble() * range);
             return min + randInRange;
         }
     }


### PR DESCRIPTION
Currently the compiler gives warnings for any public method that is missing XML comments. While XML comments are valuable, it adds a lot of noise to the compilation process that can make us miss important warnings.

Therefore this instructs the compiler to not warn in these instances.