### PR TITLE
Added better profiling system

### DIFF
--- a/Glade2d/Graphics/Renderer.cs
+++ b/Glade2d/Graphics/Renderer.cs
@@ -204,6 +204,7 @@ namespace Glade2d.Graphics
 
         public override void Show()
         {
+            GameService.Instance.GameInstance.Profiler.StartTiming("Renderer.Show");
             // If we are doing a scaled draw, we must perform special copy logic
             if (Scale > 1)
             {
@@ -223,7 +224,10 @@ namespace Glade2d.Graphics
                 display.PixelBuffer.WriteBuffer(0, 0, pixelBuffer);
             }
 
+            GameService.Instance.GameInstance.Profiler.StartTiming("Micrographics.Show");
             base.Show();
+            GameService.Instance.GameInstance.Profiler.StopTiming("Micrographics.Show");
+            GameService.Instance.GameInstance.Profiler.StopTiming("Renderer.Show");
         }
 
         void ShowSafeMode()

--- a/Glade2d/Profiling/ProfileData.cs
+++ b/Glade2d/Profiling/ProfileData.cs
@@ -1,10 +1,13 @@
-﻿namespace Glade2d.Profiling;
+﻿using System;
+using System.Linq;
 
-internal struct ProfileData
+namespace Glade2d.Profiling;
+
+internal class ProfileData
 {
     private int _nextIndex;
     private bool _rotatedAtLeastOnce;
-    private long[] _elapsedTicks;
+    private readonly long[] _elapsedTicks;
 
     public ProfileData(int capacity)
     {
@@ -12,6 +15,25 @@ internal struct ProfileData
         _rotatedAtLeastOnce = false;
         _elapsedTicks = new long[capacity];
     }
-    
-    
+
+    public void AddTicks(long ticks)
+    {
+        _elapsedTicks[_nextIndex] = ticks;
+        _nextIndex++;
+        if (_nextIndex >= _elapsedTicks.Length)
+        {
+            _nextIndex = 0;
+            _rotatedAtLeastOnce = true;
+        }
+    }
+
+    public float GetAverageTicks()
+    {
+        var sum = _elapsedTicks.Sum();
+        var length = _rotatedAtLeastOnce
+            ? _elapsedTicks.Length
+            : _nextIndex + 1;
+
+        return (float)sum / length;
+    }
 }

--- a/Glade2d/Profiling/ProfileData.cs
+++ b/Glade2d/Profiling/ProfileData.cs
@@ -1,0 +1,17 @@
+﻿namespace Glade2d.Profiling;
+
+internal struct ProfileData
+{
+    private int _nextIndex;
+    private bool _rotatedAtLeastOnce;
+    private long[] _elapsedTicks;
+
+    public ProfileData(int capacity)
+    {
+        _nextIndex = 0;
+        _rotatedAtLeastOnce = false;
+        _elapsedTicks = new long[capacity];
+    }
+    
+    
+}

--- a/Glade2d/Profiling/Profiler.cs
+++ b/Glade2d/Profiling/Profiler.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Text;
 
 namespace Glade2d.Profiling;
 
@@ -8,11 +11,13 @@ namespace Glade2d.Profiling;
 /// </summary>
 public class Profiler
 {
+    private const int StoredSampleSize = 100;
     private readonly Stopwatch _globalStopwatch = Stopwatch.StartNew();
     private readonly Dictionary<string, long> _startingTicks = new();
-    private readonly Dictionary<string, List<long>> _elapsedTicks = new();
+    private readonly Dictionary<string, ProfileData> _elapsedTicks = new();
+    private readonly StringBuilder _reportString = new(500);
     private bool _isActive;
-    private int _storedSampleSize = 100;
+    private DateTime? _lastReportAt;
 
     /// <summary>
     /// Determines if the profiler should be actively tracking operations or not. If disabled most function calls
@@ -30,6 +35,11 @@ public class Profiler
             }
         }
     }
+   
+    /// <summary>
+    /// How often profiling reports should be generated
+    /// </summary>
+    public TimeSpan TimeBetweenReports { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Resets all profiling data. Usually done when profiling is enabled or a screen change.
@@ -38,5 +48,73 @@ public class Profiler
     {
         _startingTicks.Clear();
         _elapsedTicks.Clear();
+        _lastReportAt = null;
+    }
+
+    /// <summary>
+    /// Starts timing for a named timer. If start is called for the same timer before stop is called,
+    /// then the first start time will be overwritten.
+    /// </summary>
+    public void StartTiming(string name)
+    {
+        _startingTicks[name] = _globalStopwatch.ElapsedTicks;
+    }
+
+    /// <summary>
+    /// Stops timing for the specified named timer and catalogs the duration between start and stop calls. If no
+    /// timer was started with this name than this is ignored.
+    /// </summary>
+    public void StopTiming(string name)
+    {
+        var endTicks = _globalStopwatch.ElapsedTicks;
+        if (!_isActive || !_startingTicks.TryGetValue(name, out var startTicks) || startTicks > endTicks)
+        {
+            return;
+        }
+
+        var totalTicks = endTicks - startTicks;
+        _startingTicks.Remove(name);
+        
+        if (!_elapsedTicks.TryGetValue(name, out var data))
+        {
+            data = new ProfileData(StoredSampleSize);
+            _elapsedTicks.Add(name, data);
+        }
+        
+        data.AddTicks(totalTicks);
+    }
+
+    /// <summary>
+    /// Writes the profiling report to stdout
+    /// </summary>
+    public void WriteReport()
+    {
+        if (!_isActive)
+        {
+            return;
+        }
+
+        if (_lastReportAt == null)
+        {
+            _lastReportAt = DateTime.Now;
+        }
+
+        if (DateTime.Now - _lastReportAt < TimeBetweenReports)
+        {
+            return;
+        }
+
+        const long ticksPerMilli = TimeSpan.TicksPerMillisecond;
+        _reportString.Clear();
+        _reportString.AppendLine("Profiling timings:");
+        foreach (var name in _elapsedTicks.Keys.OrderBy(x => x))
+        {
+            var averageTicks = _elapsedTicks[name].GetAverageTicks();
+            var milliseconds = averageTicks / ticksPerMilli;
+            _reportString.AppendLine($"{name}: {milliseconds}ms");
+        }
+        
+        Console.WriteLine(_reportString);
+        _lastReportAt = DateTime.Now;
     }
 }

--- a/Glade2d/Profiling/Profiler.cs
+++ b/Glade2d/Profiling/Profiler.cs
@@ -15,7 +15,7 @@ public class Profiler
     private readonly Stopwatch _globalStopwatch = Stopwatch.StartNew();
     private readonly Dictionary<string, long> _startingTicks = new();
     private readonly Dictionary<string, ProfileData> _elapsedTicks = new();
-    private readonly StringBuilder _reportString = new(500);
+    private readonly StringBuilder _reportString = new(1000);
     private bool _isActive;
     private DateTime? _lastReportAt;
 
@@ -104,6 +104,7 @@ public class Profiler
             return;
         }
 
+        var timer = Stopwatch.StartNew();
         const long ticksPerMilli = TimeSpan.TicksPerMillisecond;
         _reportString.Clear();
         _reportString.AppendLine("Profiling timings:");
@@ -116,5 +117,8 @@ public class Profiler
         
         Console.WriteLine(_reportString);
         _lastReportAt = DateTime.Now;
+        timer.Stop();
+        
+        Console.WriteLine($"Profile report took {timer.ElapsedMilliseconds}ms");
     }
 }

--- a/Glade2d/Profiling/Profiler.cs
+++ b/Glade2d/Profiling/Profiler.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Glade2d.Profiling;
+
+/// <summary>
+/// Makes it easy to track and report on performance characteristics about different operations
+/// </summary>
+public class Profiler
+{
+    private readonly Stopwatch _globalStopwatch = Stopwatch.StartNew();
+    private readonly Dictionary<string, long> _startingTicks = new();
+    private readonly Dictionary<string, List<long>> _elapsedTicks = new();
+    private bool _isActive;
+    private int _storedSampleSize = 100;
+
+    /// <summary>
+    /// Determines if the profiler should be actively tracking operations or not. If disabled most function calls
+    /// do no work.
+    /// </summary>
+    public bool IsActive
+    {
+        get => _isActive;
+        set
+        {
+            _isActive = value;
+            if (!_isActive)
+            {
+                Reset();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resets all profiling data. Usually done when profiling is enabled or a screen change.
+    /// </summary>
+    public void Reset()
+    {
+        _startingTicks.Clear();
+        _elapsedTicks.Clear();
+    }
+}

--- a/Samples/GladeInvade.Shared/GladeInvadeGame.cs
+++ b/Samples/GladeInvade.Shared/GladeInvadeGame.cs
@@ -13,6 +13,7 @@ public static class GladeInvadeGame
         // _engine.Renderer.ShowPerf = true;
 
         LogService.Log.Trace("Running game...");
+        engine.Profiler.IsActive = true;
         engine.Start(new TitleScreen());
     }
 }


### PR DESCRIPTION
Created a built in API for profiling support in games. This allows getting timings for a set of operations, and printing a report to stdout on a regular cadence.  

Profiling is disabled by default in the engine and must be enabled by each game individually. Likewise, each game can customize the interval that the report is printed on. 

An example report from Glade Invade is 

```
Meadow StdOut: Profiling timings:
Game.Draw: 168.4ms
Game.Update: 0.33ms
Micrographics.Show(): 153.8ms
Renderer.DrawSprites: 1.89ms
Renderer.RenderToDisplay: 165.82ms
Renderer.Show: 165.76ms
```