### PR TITLE
Removed display rotation from engine

### DIFF
--- a/Glade2d/Game.cs
+++ b/Glade2d/Game.cs
@@ -40,7 +40,10 @@ namespace Glade2d
 
         public Game() { }
 
-        public virtual void Initialize(IGraphicsDisplay display, int displayScale = 1, EngineMode mode = EngineMode.GameLoop, RotationType displayRotation = RotationType.Default)
+        public virtual void Initialize(
+            IGraphicsDisplay display, 
+            int displayScale = 1, 
+            EngineMode mode = EngineMode.GameLoop)
         {
             LogService.Log.Trace("Initializing Renderer...");
 
@@ -48,7 +51,7 @@ namespace Glade2d
             GameService.Instance.GameInstance = this;
 
             // init renderer
-            Renderer = new Renderer(display, displayScale, displayRotation);
+            Renderer = new Renderer(display, displayScale);
 
             Mode = mode;
 

--- a/Glade2d/Graphics/Renderer.cs
+++ b/Glade2d/Graphics/Renderer.cs
@@ -23,11 +23,10 @@ namespace Glade2d.Graphics
         public bool UseTransparency { get; set; } = true;
         public bool RenderInSafeMode { get; set; } = false;
 
-        public Renderer(IGraphicsDisplay display, int scale = 1, RotationType rotation = RotationType.Default)
+        public Renderer(IGraphicsDisplay display, int scale = 1)
             : base(display)
         {
-            this.Scale = scale;
-            this.Rotation = rotation;
+            Scale = scale;
 
             // If we are rendering at a different resolution than our
             // device, we need to create a new buffer as our primary drawing buffer
@@ -84,7 +83,6 @@ namespace Glade2d.Graphics
 
             var imgBufferWidth = imgBuffer.Width;
             var pixelBufferWidth = pixelBuffer.Width;
-            var pixelBufferHeight = pixelBuffer.Height;
             var frameHeight = frame.Height;
             var frameWidth = frame.Width;
             var frameX = frame.X;
@@ -99,8 +97,6 @@ namespace Glade2d.Graphics
                     var tX = originX + x - frameX;
                     var tY = originY + y - frameY;
                     
-                    RotateCoordinates(ref tX, ref tY, pixelBufferWidth, pixelBufferHeight, Rotation);
-
                     // only draw if not transparent and within buffer
                     if (tX >= 0 && tY >= 0 && tX < _width && tY < _height)
                     {
@@ -319,39 +315,6 @@ namespace Glade2d.Graphics
             }
 
             return buffer;
-        }
-
-        /// <summary>
-        /// Takes target coordinates and adjusts them for a rotated display
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void RotateCoordinates(ref int x, ref int y, int width, int height, RotationType rotationType)
-        {
-            switch (rotationType)
-            {
-                case RotationType._90Degrees:
-                {
-                    var temp = y;
-                    y = x;
-                    x = width - temp;
-                    break;
-                }
-
-                case RotationType._180Degrees:
-                {
-                    x = width - x;
-                    y = height - y;
-                    break;
-                }
-
-                case RotationType._270Degrees:
-                {
-                    var temp = y;
-                    y = width - x;
-                    x = temp;
-                    break;
-                }
-            }
         }
 
         /// <summary>

--- a/Samples/GladeInvade.ProjectLab/MeadowApp.cs
+++ b/Samples/GladeInvade.ProjectLab/MeadowApp.cs
@@ -4,6 +4,7 @@ using Glade2d.Services;
 using GladeInvade.Shared;
 using Meadow;
 using Meadow.Devices;
+using Meadow.Foundation.Displays;
 using Meadow.Foundation.Graphics;
 
 namespace GladeInvade.ProjectLab;
@@ -16,7 +17,8 @@ public class MeadowApp : App<F7FeatherV2>
     public override Task Initialize()
     {
         _projectLab = new Meadow.Devices.ProjectLab();
-        _display = _projectLab.Display!;
+        _projectLab.Display!.SetRotation(TftSpiBase.Rotation.Rotate_90);
+        _display = _projectLab.Display;
         
         return base.Initialize();
     }
@@ -25,7 +27,7 @@ public class MeadowApp : App<F7FeatherV2>
     {
         LogService.Log.Trace("Initializing Glade game engine...");
         var glade = new Game();
-        glade.Initialize(_display, 2, EngineMode.GameLoop, RotationType._90Degrees);
+        glade.Initialize(_display, 2, EngineMode.GameLoop);
         InitializeInput(glade.InputManager);
         
         GladeInvadeGame.Run(glade);

--- a/Samples/SampleInput/MeadowApp.cs
+++ b/Samples/SampleInput/MeadowApp.cs
@@ -60,7 +60,7 @@ namespace SampleInput
         {
             LogService.Log.Trace("Starting Glade2d...");
             glade = new Game();
-            glade.Initialize(display, 1, EngineMode.RenderOnDemand, RotationType._90Degrees);
+            glade.Initialize(display, 1, EngineMode.RenderOnDemand);
             glade.Start();
         }
 
@@ -87,7 +87,7 @@ namespace SampleInput
             var chipSelectPort = mcp.CreateDigitalOutputPort(mcp.Pins.GP5);
             var dcPort = mcp.CreateDigitalOutputPort(mcp.Pins.GP6);
             var resetPort = mcp.CreateDigitalOutputPort(mcp.Pins.GP7);
-            display = new St7789(
+            var st7789 = new St7789(
                 spiBus: spi,
                 chipSelectPort: chipSelectPort,
                 dataCommandPort: dcPort,
@@ -95,6 +95,9 @@ namespace SampleInput
                 width: 240, height: 240,
                 colorMode: ColorType.Format16bppRgb565
                 );
+            
+            st7789.SetRotation(TftSpiBase.Rotation.Rotate_90);
+            display = st7789;
         }
 
         void InitializeInput()

--- a/Samples/SampleProjectLab/MeadowApp.cs
+++ b/Samples/SampleProjectLab/MeadowApp.cs
@@ -21,7 +21,7 @@ namespace SampleProjectLab
         {
             LogService.Log.Trace("Initializing Glade game engine...");
             glade = new Game();
-            glade.Initialize(display, 2, EngineMode.GameLoop, RotationType._90Degrees);
+            glade.Initialize(display, 2, EngineMode.GameLoop);
 
             LogService.Log.Trace("Running game...");
             glade.Start(new GladeDemoScreen());
@@ -35,7 +35,7 @@ namespace SampleProjectLab
             return base.Initialize();
         }
 
-        void InitializeDisplay()
+        private void InitializeDisplay()
         {
             LogService.Log.Trace("Initializing SPI bus...");
             var config = new SpiClockConfiguration(
@@ -55,7 +55,8 @@ namespace SampleProjectLab
             var chipSelectPort = mcp.CreateDigitalOutputPort(mcp.Pins.GP5);
             var dcPort = mcp.CreateDigitalOutputPort(mcp.Pins.GP6);
             var resetPort = mcp.CreateDigitalOutputPort(mcp.Pins.GP7);
-            display = new St7789(
+            
+            var st7789 = new St7789(
                 spiBus: spi,
                 chipSelectPort: chipSelectPort,
                 dataCommandPort: dcPort,
@@ -63,6 +64,10 @@ namespace SampleProjectLab
                 width: 240, height: 240,
                 colorMode: ColorType.Format16bppRgb565
                 );
+            
+            st7789.SetRotation(TftSpiBase.Rotation.Rotate_90);
+
+            display = st7789;
         }
     }
 }


### PR DESCRIPTION
Currently, when we draw a sprite we go transform every pixel's x and y coordinates based on the display rotation.

Not only does this add extra complexity and CPU overhead for each sprite that needs to be rendered, it also limits rendering optimizations that can be done.

Instead, we can rely on individual display drivers managing the rotation.  This allows us to manage the byte buffer and sprites without rotations, and allow the display driver to properly handle the rotation.

This won't be functional right away, but requires a Meadow PR to land and propagate out to nuget (https://github.com/WildernessLabs/Meadow.Foundation/pull/528).