### PR TITLE
Don't rotate the display for project lab

### DIFF
--- a/Samples/GladeInvade.ProjectLab/MeadowApp.cs
+++ b/Samples/GladeInvade.ProjectLab/MeadowApp.cs
@@ -17,8 +17,8 @@ public class MeadowApp : App<F7FeatherV2>
     public override Task Initialize()
     {
         _projectLab = new Meadow.Devices.ProjectLab();
-        _projectLab.Display!.SetRotation(TftSpiBase.Rotation.Rotate_90);
-        _display = _projectLab.Display;
+        // _projectLab.Display!.SetRotation(TftSpiBase.Rotation.Rotate_90);
+        _display = _projectLab.Display!;
         
         return base.Initialize();
     }

--- a/Samples/SampleProjectLab/MeadowApp.cs
+++ b/Samples/SampleProjectLab/MeadowApp.cs
@@ -21,8 +21,7 @@ namespace SampleProjectLab
         {
             LogService.Log.Trace("Initializing Glade game engine...");
             glade = new Game();
-            glade.Initialize(display, 1, EngineMode.GameLoop);
-            glade.Profiler.IsActive = true;
+            glade.Initialize(display, 2, EngineMode.GameLoop);
 
             LogService.Log.Trace("Running game...");
             glade.Start(new GladeDemoScreen());

--- a/Samples/SampleProjectLab/MeadowApp.cs
+++ b/Samples/SampleProjectLab/MeadowApp.cs
@@ -21,7 +21,8 @@ namespace SampleProjectLab
         {
             LogService.Log.Trace("Initializing Glade game engine...");
             glade = new Game();
-            glade.Initialize(display, 2, EngineMode.GameLoop);
+            glade.Initialize(display, 1, EngineMode.GameLoop);
+            glade.Profiler.IsActive = true;
 
             LogService.Log.Trace("Running game...");
             glade.Start(new GladeDemoScreen());
@@ -65,7 +66,7 @@ namespace SampleProjectLab
                 colorMode: ColorType.Format16bppRgb565
                 );
             
-            st7789.SetRotation(TftSpiBase.Rotation.Rotate_90);
+            // st7789.SetRotation(TftSpiBase.Rotation.Rotate_90);
 
             display = st7789;
         }


### PR DESCRIPTION
Previously, we moved rotation out of the engine and instead used the St7789's `SetRotation()` method to perform this.

However, until a Meadow labs bug is merged and released in a nuget, this is buggy.  So to prevent this from disrupting development efforts before then the display should have no rotation.