### PR TITLE
Monogame and Juego project fixes

### DIFF
--- a/Glade2d/Graphics/Drawing.cs
+++ b/Glade2d/Graphics/Drawing.cs
@@ -92,8 +92,9 @@ internal static class Drawing
                     {
                         if (*sourceByte1 != transparencyColorByte1 || *sourceByte2 != transparencyColorByte2)
                         {
-                            *targetByte1 = *sourceByte1;
-                            *targetByte2 = *sourceByte2;
+                            var source = (ushort*)targetByte1;
+                            var target = (ushort*)targetByte2;
+                            *target = *source;
                         }
 
                         sourceByte1 += BytesPerPixel;

--- a/Glade2d/Graphics/Drawing.cs
+++ b/Glade2d/Graphics/Drawing.cs
@@ -92,9 +92,8 @@ internal static class Drawing
                     {
                         if (*sourceByte1 != transparencyColorByte1 || *sourceByte2 != transparencyColorByte2)
                         {
-                            var source = (ushort*)targetByte1;
-                            var target = (ushort*)targetByte2;
-                            *target = *source;
+                            *targetByte1 = *sourceByte1;
+                            *targetByte2 = *sourceByte2;
                         }
 
                         sourceByte1 += BytesPerPixel;

--- a/Samples/GladeInvade.Juego/MeadowApp.cs
+++ b/Samples/GladeInvade.Juego/MeadowApp.cs
@@ -30,7 +30,7 @@ public class MeadowApp : App<Meadow.Devices.F7CoreComputeV2>
     {
         LogService.Log.Trace("Initializing Glade game engine...");
         var engine = new Game();
-        engine.Initialize(_display, 2, displayRotation: DisplayRotation.Rotated270Degrees);
+        engine.Initialize(_display, 2, displayRotation: RotationType._270Degrees);
         SetupInputs(engine.InputManager);
 
         GladeInvadeGame.Run(engine);

--- a/Samples/GladeInvade.Monogame/GladeInvade.Monogame.csproj
+++ b/Samples/GladeInvade.Monogame/GladeInvade.Monogame.csproj
@@ -11,8 +11,9 @@
       <ProjectReference Include="..\..\Glade2d\Glade2d.csproj" />
       <ProjectReference Include="..\GladeInvade.Shared\GladeInvade.Shared.csproj" />
       <PackageReference Include="Meadow.Foundation" Version="0.95.0" />
+      <PackageReference Include="Meadow.Foundation.Graphics.MicroGraphics" Version="0.95.0" />
       <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.0" />
+      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Samples/GladePlatformer.Juego/MeadowApp.cs
+++ b/Samples/GladePlatformer.Juego/MeadowApp.cs
@@ -30,7 +30,7 @@ public class MeadowApp : App<Meadow.Devices.F7CoreComputeV2>
     {
         LogService.Log.Trace("Initializing Glade game engine...");
         var glade = new Game();
-        glade.Initialize(_display, 2, displayRotation: DisplayRotation.Rotated270Degrees);
+        glade.Initialize(_display, 2, displayRotation: RotationType._270Degrees);
         SetupInputs(glade.InputManager);
 
         GladePlatformerGame.Run(glade);

--- a/Samples/GladePlatformer.Monogame/GladePlatformer.Monogame.csproj
+++ b/Samples/GladePlatformer.Monogame/GladePlatformer.Monogame.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="Meadow.Foundation" Version="0.95.0" />
-      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.0" />
+      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.1" />
       <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     </ItemGroup>
 


### PR DESCRIPTION
Due to an out of date Juego branch, Juego projects were using the incorrect rotation enum that no longer exists, thus these no longer compiled.

Likewise, the nuget packages for the MG test environment was updated for a nuget package that properly cataloged its dependencies.