### PR TITLE
Created easier game input API

### DIFF
--- a/Glade2d/Game.cs
+++ b/Glade2d/Game.cs
@@ -73,6 +73,18 @@ namespace Glade2d
             LogService.Log.Trace("Renderer Initialized.");
         }
 
+        public virtual void Initialize<TInput>(
+            IGraphicsDisplay display,
+            TInput gameInput,
+            int displayScale = 1,
+            EngineMode mode = EngineMode.GameLoop,
+            string contentRoot = null,
+            RotationType displayRotation = RotationType.Default) where TInput : GameInputSetBase
+        {
+            Initialize(display, displayScale, mode, contentRoot, displayRotation);
+            gameInput.SetupInput(InputManager);
+        }
+
         public void Start(Screen startupScreen = null)
         {
             if (GameService.Instance.CurrentScreen is IDisposable oldScreen)

--- a/Glade2d/Graphics/Drawing.cs
+++ b/Glade2d/Graphics/Drawing.cs
@@ -92,8 +92,9 @@ internal static class Drawing
                     {
                         if (*sourceByte1 != transparencyColorByte1 || *sourceByte2 != transparencyColorByte2)
                         {
-                            *targetByte1 = *sourceByte1;
-                            *targetByte2 = *sourceByte2;
+                            var source = (ushort*)targetByte1;
+                            var target = (ushort*)targetByte2;
+                            *target = *source;
                         }
 
                         sourceByte1 += BytesPerPixel;

--- a/Glade2d/Graphics/Drawing.cs
+++ b/Glade2d/Graphics/Drawing.cs
@@ -92,9 +92,8 @@ internal static class Drawing
                     {
                         if (*sourceByte1 != transparencyColorByte1 || *sourceByte2 != transparencyColorByte2)
                         {
-                            var source = (ushort*)targetByte1;
-                            var target = (ushort*)targetByte2;
-                            *target = *source;
+                            *targetByte1 = *sourceByte1;
+                            *targetByte2 = *sourceByte2;
                         }
 
                         sourceByte1 += BytesPerPixel;

--- a/Glade2d/Input/GameInputSetBase.cs
+++ b/Glade2d/Input/GameInputSetBase.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using System.Reflection;
+using Meadow.Hardware;
+
+namespace Glade2d.Input;
+
+/// <summary>
+/// Represents a set of inputs that a game reacts to
+/// </summary>
+public abstract class GameInputSetBase
+{
+    internal void SetupInput(InputManager inputManager)
+    {
+        // Find all digital ports defined
+        var digitalPortProperties = GetType()
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(x => typeof(IDigitalInputPort).IsAssignableFrom(x.PropertyType))
+            .ToArray();
+
+        foreach (var digitalPortProperty in digitalPortProperties)
+        {
+            var port = (IDigitalInputPort)digitalPortProperty.GetValue(this);
+            var name = digitalPortProperty.Name;
+            
+            inputManager.RegisterInputPort(port, name);
+        }
+    }
+}

--- a/Samples/GladeInvade.Juego/MeadowApp.cs
+++ b/Samples/GladeInvade.Juego/MeadowApp.cs
@@ -30,8 +30,8 @@ public class MeadowApp : App<Meadow.Devices.F7CoreComputeV2>
     {
         LogService.Log.Trace("Initializing Glade game engine...");
         var engine = new Game();
-        engine.Initialize(_display, 2, displayRotation: RotationType._270Degrees);
-        SetupInputs(engine.InputManager);
+        var inputs = SetupInputs();
+        engine.Initialize(_display, inputs, 2, displayRotation: RotationType._270Degrees);
 
         GladeInvadeGame.Run(engine);
 
@@ -81,14 +81,17 @@ public class MeadowApp : App<Meadow.Devices.F7CoreComputeV2>
         _display = ili9341;
     }
 
-    private void SetupInputs(InputManager inputManager)
+    private GameInputs SetupInputs()
     {
         var dPadLeftPort = _mcp1.CreateDigitalInputPort(_mcp1.Pins.GP4, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
         var dPadRightPort = _mcp1.CreateDigitalInputPort(_mcp1.Pins.GP2, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
         var btnDownPort = _mcp2.CreateDigitalInputPort(_mcp2.Pins.GP3, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-        
-        inputManager.RegisterPushButton(new PushButton(dPadLeftPort), GameConstants.InputNames.Left);
-        inputManager.RegisterPushButton(new PushButton(dPadRightPort), GameConstants.InputNames.Right);
-        inputManager.RegisterPushButton(new PushButton(btnDownPort), GameConstants.InputNames.Action);
+
+        return new GameInputs
+        {
+            Left = dPadLeftPort,
+            Right = dPadRightPort,
+            Action = btnDownPort,
+        };
     }
 }

--- a/Samples/GladeInvade.Juego/MeadowApp.cs
+++ b/Samples/GladeInvade.Juego/MeadowApp.cs
@@ -30,7 +30,7 @@ public class MeadowApp : App<Meadow.Devices.F7CoreComputeV2>
     {
         LogService.Log.Trace("Initializing Glade game engine...");
         var engine = new Game();
-        engine.Initialize(_display, 2, displayRotation: DisplayRotation.Rotated270Degrees);
+        engine.Initialize(_display, 2, displayRotation: RotationType._270Degrees);
         SetupInputs(engine.InputManager);
 
         GladeInvadeGame.Run(engine);

--- a/Samples/GladeInvade.Monogame/GladeInvade.Monogame.csproj
+++ b/Samples/GladeInvade.Monogame/GladeInvade.Monogame.csproj
@@ -13,7 +13,7 @@
       <PackageReference Include="Meadow.Foundation" Version="0.95.0" />
       <PackageReference Include="Meadow.Foundation.Graphics.MicroGraphics" Version="0.95.0" />
       <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.1" />
+      <PackageReference Include="MeadowMgTestEnvironment" Version="1.2.0" />
     </ItemGroup>
 
 </Project>

--- a/Samples/GladeInvade.Monogame/GladeInvade.Monogame.csproj
+++ b/Samples/GladeInvade.Monogame/GladeInvade.Monogame.csproj
@@ -11,8 +11,9 @@
       <ProjectReference Include="..\..\Glade2d\Glade2d.csproj" />
       <ProjectReference Include="..\GladeInvade.Shared\GladeInvade.Shared.csproj" />
       <PackageReference Include="Meadow.Foundation" Version="0.95.0" />
+      <PackageReference Include="Meadow.Foundation.Graphics.MicroGraphics" Version="0.95.0" />
       <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.0" />
+      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Samples/GladeInvade.Monogame/Program.cs
+++ b/Samples/GladeInvade.Monogame/Program.cs
@@ -5,19 +5,13 @@ using Microsoft.Xna.Framework.Input;
 
 var environment = new TestEnvironment(240, 240);
 var engine = new Game();
-engine.Initialize(environment.Display, 2, contentRoot: Environment.CurrentDirectory);
 
-var inputManager = engine.InputManager;
-environment.BindKey(Keys.Right, 
-    () => inputManager.ButtonPushed(GameConstants.InputNames.Right),
-    () => inputManager.ButtonReleased(GameConstants.InputNames.Right));
+var inputs = new GameInputs
+{
+    Left = environment.CreatePortForKey(Keys.Left),
+    Right = environment.CreatePortForKey(Keys.Right),
+    Action = environment.CreatePortForKey(Keys.Up),
+};
 
-environment.BindKey(Keys.Left,
-    () => inputManager.ButtonPushed(GameConstants.InputNames.Left),
-    () => inputManager.ButtonReleased(GameConstants.InputNames.Left));
-
-environment.BindKey(Keys.Up,
-    () => inputManager.ButtonPushed(GameConstants.InputNames.Action),
-    () => inputManager.ButtonReleased(GameConstants.InputNames.Action));
-
+engine.Initialize(environment.Display, inputs, 2, contentRoot: Environment.CurrentDirectory);
 GladeInvadeGame.Run(engine);

--- a/Samples/GladeInvade.ProjectLab/MeadowApp.cs
+++ b/Samples/GladeInvade.ProjectLab/MeadowApp.cs
@@ -17,7 +17,6 @@ public class MeadowApp : App<F7FeatherV2>
     public override Task Initialize()
     {
         _projectLab = Meadow.Devices.ProjectLab.Create();
-        // _projectLab.Display!.SetRotation(TftSpiBase.Rotation.Rotate_90);
         _display = _projectLab.Display!;
         
         return base.Initialize();
@@ -37,8 +36,9 @@ public class MeadowApp : App<F7FeatherV2>
 
     private void InitializeInput(InputManager inputManager)
     {
-        inputManager.RegisterPushButton(_projectLab.UpButton!, GameConstants.InputNames.Action);
-        inputManager.RegisterPushButton(_projectLab.LeftButton!, GameConstants.InputNames.Left);
-        inputManager.RegisterPushButton(_projectLab.RightButton!, GameConstants.InputNames.Right);
+        // can't use input ports directly with the PL abstraction
+        inputManager.RegisterPushButton(_projectLab.UpButton!, nameof(GameInputs.Action));
+        inputManager.RegisterPushButton(_projectLab.LeftButton!, nameof(GameInputs.Left));
+        inputManager.RegisterPushButton(_projectLab.RightButton!, nameof(GameInputs.Right));
     }
 }

--- a/Samples/GladeInvade.Shared/GameConstants.cs
+++ b/Samples/GladeInvade.Shared/GameConstants.cs
@@ -9,25 +9,4 @@ public static class GameConstants
     /// The name of the global sprite sheet to load textures from
     /// </summary>
     public const string SpriteSheetName = "glade-invade.bmp";
-
-    /// <summary>
-    /// Names for different inputs that can be used
-    /// </summary>
-    public static class InputNames
-    {
-        /// <summary>
-        /// Name of the input to perform an action, such as shooting
-        /// </summary>
-        public const string Action = "action";
-        
-        /// <summary>
-        /// Name of the button to move left
-        /// </summary>
-        public const string Left = "left";
-        
-        /// <summary>
-        /// Name of the input to move right
-        /// </summary>
-        public const string Right = "Right";
-    }
 }

--- a/Samples/GladeInvade.Shared/GameInputs.cs
+++ b/Samples/GladeInvade.Shared/GameInputs.cs
@@ -1,0 +1,11 @@
+﻿using Glade2d.Input;
+using Meadow.Hardware;
+
+namespace GladeInvade.Shared;
+
+public class GameInputs : GameInputSetBase
+{
+    public IDigitalInputPort Left { get; set; }
+    public IDigitalInputPort Right { get; set; }
+    public IDigitalInputPort Action { get; set; }
+}

--- a/Samples/GladeInvade.Shared/Screens/GameScreen.cs
+++ b/Samples/GladeInvade.Shared/Screens/GameScreen.cs
@@ -84,11 +84,11 @@ public class GameScreen : Screen
 
     private void ProcessPlayerMovement()
     {
-        if (_engine.InputManager.GetButtonState(GameConstants.InputNames.Left) == ButtonState.Down)
+        if (_engine.InputManager.GetButtonState(nameof(GameInputs.Left)) == ButtonState.Down)
         {
             _player.MoveLeft();
         }
-        else if (_engine.InputManager.GetButtonState(GameConstants.InputNames.Right) == ButtonState.Down)
+        else if (_engine.InputManager.GetButtonState(nameof(GameInputs.Right)) == ButtonState.Down)
         {
             _player.MoveRight();
         }
@@ -151,7 +151,7 @@ public class GameScreen : Screen
 
     private void ProcessPlayerShots()
     {
-        if (_engine.InputManager.GetButtonState(GameConstants.InputNames.Action) == ButtonState.Pressed)
+        if (_engine.InputManager.GetButtonState(nameof(GameInputs.Action)) == ButtonState.Pressed)
         {
             var shot = new PlayerShot
             {

--- a/Samples/GladeInvade.Shared/Screens/TitleScreen.cs
+++ b/Samples/GladeInvade.Shared/Screens/TitleScreen.cs
@@ -31,7 +31,7 @@ public class TitleScreen : Screen
 
     public override void Activity()
     {
-        if (_engine.InputManager.GetButtonState(GameConstants.InputNames.Action) == ButtonState.Pressed)
+        if (_engine.InputManager.GetButtonState(nameof(GameInputs.Action)) == ButtonState.Pressed)
         {
             GameService.Instance.CurrentScreen = new GameScreen();
         }

--- a/Samples/GladePlatformer.Juego/MeadowApp.cs
+++ b/Samples/GladePlatformer.Juego/MeadowApp.cs
@@ -30,8 +30,8 @@ public class MeadowApp : App<Meadow.Devices.F7CoreComputeV2>
     {
         LogService.Log.Trace("Initializing Glade game engine...");
         var glade = new Game();
-        glade.Initialize(_display, 2, displayRotation: RotationType._270Degrees);
-        SetupInputs(glade.InputManager);
+        var inputs = SetupInputs();
+        glade.Initialize(_display, inputs, 2, displayRotation: RotationType._270Degrees);
 
         GladePlatformerGame.Run(glade);
 
@@ -81,14 +81,17 @@ public class MeadowApp : App<Meadow.Devices.F7CoreComputeV2>
         _display = ili9341;
     }
 
-    private void SetupInputs(InputManager inputManager)
+    private GameInputs SetupInputs()
     {
         var dPadLeftPort = _mcp1.CreateDigitalInputPort(_mcp1.Pins.GP4, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
         var dPadRightPort = _mcp1.CreateDigitalInputPort(_mcp1.Pins.GP2, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
         var btnDownPort = _mcp2.CreateDigitalInputPort(_mcp2.Pins.GP3, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-        
-        inputManager.RegisterPushButton(new PushButton(dPadLeftPort), GameConstants.InputNames.Left);
-        inputManager.RegisterPushButton(new PushButton(dPadRightPort), GameConstants.InputNames.Right);
-        inputManager.RegisterPushButton(new PushButton(btnDownPort), GameConstants.InputNames.Jump);
+
+        return new GameInputs
+        {
+            Left = dPadLeftPort,
+            Right = dPadRightPort,
+            Jump = btnDownPort,
+        };
     }
 }

--- a/Samples/GladePlatformer.Juego/MeadowApp.cs
+++ b/Samples/GladePlatformer.Juego/MeadowApp.cs
@@ -30,7 +30,7 @@ public class MeadowApp : App<Meadow.Devices.F7CoreComputeV2>
     {
         LogService.Log.Trace("Initializing Glade game engine...");
         var glade = new Game();
-        glade.Initialize(_display, 2, displayRotation: DisplayRotation.Rotated270Degrees);
+        glade.Initialize(_display, 2, displayRotation: RotationType._270Degrees);
         SetupInputs(glade.InputManager);
 
         GladePlatformerGame.Run(glade);

--- a/Samples/GladePlatformer.Monogame/GladePlatformer.Monogame.csproj
+++ b/Samples/GladePlatformer.Monogame/GladePlatformer.Monogame.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="Meadow.Foundation" Version="0.95.0" />
-      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.0" />
+      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.1" />
       <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     </ItemGroup>
 

--- a/Samples/GladePlatformer.Monogame/GladePlatformer.Monogame.csproj
+++ b/Samples/GladePlatformer.Monogame/GladePlatformer.Monogame.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="Meadow.Foundation" Version="0.95.0" />
-      <PackageReference Include="MeadowMgTestEnvironment" Version="1.0.1" />
+      <PackageReference Include="MeadowMgTestEnvironment" Version="1.2.0" />
       <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     </ItemGroup>
 

--- a/Samples/GladePlatformer.Monogame/Program.cs
+++ b/Samples/GladePlatformer.Monogame/Program.cs
@@ -6,23 +6,19 @@ using Microsoft.Xna.Framework.Input;
 
 var environment = new TestEnvironment(240, 320);
 var engine = new Game();
+
+var input = new GameInputs
+{
+    Left = environment.CreatePortForKey(Keys.Left),
+    Right = environment.CreatePortForKey(Keys.Right),
+    Jump = environment.CreatePortForKey(Keys.Up),
+};
+
 engine.Initialize(
     environment.Display, 
+    input,
     2, 
     contentRoot: Environment.CurrentDirectory,
     displayRotation: RotationType.Default);
-
-var inputManager = engine.InputManager;
-environment.BindKey(Keys.Right, 
-    () => inputManager.ButtonPushed(GameConstants.InputNames.Right),
-    () => inputManager.ButtonReleased(GameConstants.InputNames.Right));
-
-environment.BindKey(Keys.Left,
-    () => inputManager.ButtonPushed(GameConstants.InputNames.Left),
-    () => inputManager.ButtonReleased(GameConstants.InputNames.Left));
-
-environment.BindKey(Keys.Up,
-    () => inputManager.ButtonPushed(GameConstants.InputNames.Jump),
-    () => inputManager.ButtonReleased(GameConstants.InputNames.Jump));
 
 GladePlatformerGame.Run(engine);

--- a/Samples/GladePlatformer.ProjectLab/MeadowApp.cs
+++ b/Samples/GladePlatformer.ProjectLab/MeadowApp.cs
@@ -36,8 +36,8 @@ public class MeadowApp : App<F7FeatherV2>
 
     private void InitializeInput(InputManager inputManager)
     {
-        inputManager.RegisterPushButton(_projectLab.UpButton!, GameConstants.InputNames.Jump);
-        inputManager.RegisterPushButton(_projectLab.LeftButton!, GameConstants.InputNames.Left);
-        inputManager.RegisterPushButton(_projectLab.RightButton!, GameConstants.InputNames.Right);
+        inputManager.RegisterPushButton(_projectLab.UpButton!, nameof(GameInputs.Jump));
+        inputManager.RegisterPushButton(_projectLab.LeftButton!, nameof(GameInputs.Left));
+        inputManager.RegisterPushButton(_projectLab.RightButton!, nameof(GameInputs.Right));
     }
 }

--- a/Samples/GladePlatformer.Shared/Entities/Player.cs
+++ b/Samples/GladePlatformer.Shared/Entities/Player.cs
@@ -33,8 +33,8 @@ public class Player : Sprite
     {
         var inputManager = GameService.Instance.GameInstance.InputManager;
         var wasWalking = _isWalking;
-        _isWalking = inputManager.GetButtonState(GameConstants.InputNames.Left) == ButtonState.Down ||
-                     inputManager.GetButtonState(GameConstants.InputNames.Right) == ButtonState.Down;
+        _isWalking = inputManager.GetButtonState(nameof(GameInputs.Left)) == ButtonState.Down ||
+                     inputManager.GetButtonState(nameof(GameInputs.Right)) == ButtonState.Down;
 
         if (_isWalking)
         {

--- a/Samples/GladePlatformer.Shared/GameConstants.cs
+++ b/Samples/GladePlatformer.Shared/GameConstants.cs
@@ -3,25 +3,4 @@
 public class GameConstants
 {
     public const string SpriteSheetName = "spritesheet.bmp";
-    
-    /// <summary>
-    /// Names for different inputs that can be used
-    /// </summary>
-    public static class InputNames
-    {
-        /// <summary>
-        /// Name of the input to perform an action, such as shooting
-        /// </summary>
-        public const string Jump = "action";
-        
-        /// <summary>
-        /// Name of the button to move left
-        /// </summary>
-        public const string Left = "left";
-        
-        /// <summary>
-        /// Name of the input to move right
-        /// </summary>
-        public const string Right = "right";
-    }
 }

--- a/Samples/GladePlatformer.Shared/GameInputs.cs
+++ b/Samples/GladePlatformer.Shared/GameInputs.cs
@@ -1,0 +1,11 @@
+﻿using Glade2d.Input;
+using Meadow.Hardware;
+
+namespace GladePlatformer.Shared;
+
+public class GameInputs : GameInputSetBase
+{
+    public IDigitalInputPort? Left { get; set; }
+    public IDigitalInputPort? Right { get; set; }
+    public IDigitalInputPort? Jump { get; set; }
+}

--- a/Samples/GladePlatformer.Shared/Screens/LevelScreen.cs
+++ b/Samples/GladePlatformer.Shared/Screens/LevelScreen.cs
@@ -61,17 +61,17 @@ public class LevelScreen : Screen, IDisposable
         _player.VelocityY = playerVelocityY;
 
         var inputManager = GameService.Instance.GameInstance.InputManager;
-        if (inputManager.GetButtonState(GameConstants.InputNames.Right) == ButtonState.Down)
+        if (inputManager.GetButtonState(nameof(GameInputs.Right)) == ButtonState.Down)
         {
             _playerVelocityX = PlayerSpeed;
         }
-        else if (inputManager.GetButtonState(GameConstants.InputNames.Left) == ButtonState.Down)
+        else if (inputManager.GetButtonState(nameof(GameInputs.Left)) == ButtonState.Down)
         {
             _playerVelocityX = -PlayerSpeed;
         }
         
         _player.VelocityY += Gravity;
-        if (inputManager.GetButtonState(GameConstants.InputNames.Jump) == ButtonState.Pressed)
+        if (inputManager.GetButtonState(nameof(GameInputs.Jump)) == ButtonState.Pressed)
         {
             _player.VelocityY += JumpAcceleration;
         }


### PR DESCRIPTION
To make handling input easier, glade games can define their own `GameInputSet` subclass.  Games can define properties of type `iDigitalInputPort` and have those inputs automatically tracked by Glade by their property name.